### PR TITLE
Remove duplicate find-links

### DIFF
--- a/ftw/bob/web/template/+package.fullname+/deployment-base.cfg.bob
+++ b/ftw/bob/web/template/+package.fullname+/deployment-base.cfg.bob
@@ -18,6 +18,3 @@ instance-eggs =
 filestorage-parts = {{{package.fullname}}}
 develop = .
 supervisor-client-startsecs = 20
-
-find-links +=
-    http://psc.4teamwork.ch/simple


### PR DESCRIPTION
In `sources.cfg` we include the [4teamwork-psc.cfg](https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/4teamwork-psc.cfg) which already extends `find-links`.
Thus, extending the `find-links` is not needed in the production config.
