### PR TITLE
Unpin buildout by default.

### DIFF
--- a/ftw/bob/web/template/+package.fullname+/versions.cfg.bob
+++ b/ftw/bob/web/template/+package.fullname+/versions.cfg.bob
@@ -2,3 +2,6 @@
 extends = http://dist.plone.org/release/{{{package.plone_version}}}/versions.cfg
 
 [versions]
+zc.buildout =
+setuptools =
+distribute =


### PR DESCRIPTION
By unpinning zc.buildout (& co), we get zc.buildout 2, which shows us picked versions.
