### PR TITLE
Add link of documentation to readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,9 @@ Generating a new policy package
 
     $ bin/create
 
-You only have to answer all the questions and your policy will be created in the ``generated``.
+You only have to answer all the questions and your policy will be created in the ``generated`` folder.
+
+A complete documentation for deployments with ftw.bob can be found here: http://devdocs.4teamwork.ch/plone/deployment/deployment/
 
 Development
 -----------


### PR DESCRIPTION
Adds a link to the complete deployment documentation to the readme.

closes #32 
