### PR TITLE
Remove news block from root

### DIFF
--- a/bobtemplates/web/+package.fullname+/+package.part_1+/+package.part_2+/profiles/examplecontent/content_creation/01_content.json.bob
+++ b/bobtemplates/web/+package.fullname+/+package.part_1+/+package.part_2+/profiles/examplecontent/content_creation/01_content.json.bob
@@ -168,15 +168,6 @@
         "text": "<p>Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.<p/>"
     },
     {
-        "_path": "nachrichten",
-        "_type": "ftw.news.NewsListingBlock",
-        "news_listing_config_title": "Nachrichten",
-        "current_context": false,
-        "quantity": 5,
-        "filter_by_path": [],
-        "subjects": []
-    },
-    {
         "_path": "example-subsite",
         "_type": "ftw.subsite.Subsite",
         "title": "Some Subsite",


### PR DESCRIPTION
Removes a wrongly placed NewsListingBlock from the plone root.

closes #62
