### PR TITLE
Allow types to be excluded from navigation

### DIFF
--- a/bobtemplates/web/+package.fullname+/+package.part_1+/+package.part_2+/profiles/default/types/ftw.news.NewsFolder.xml
+++ b/bobtemplates/web/+package.fullname+/+package.part_1+/+package.part_2+/profiles/default/types/ftw.news.NewsFolder.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<object name="ftw.news.NewsFolder" meta_type="Dexterity FTI">
+
+    <property name="behaviors" purge="False">
+        <element value="plone.app.dexterity.behaviors.exclfromnav.IExcludeFromNavigation"/>
+    </property>
+
+</object>

--- a/bobtemplates/web/+package.fullname+/+package.part_1+/+package.part_2+/profiles/default/types/ftw.simplelayout.ContentPage.xml
+++ b/bobtemplates/web/+package.fullname+/+package.part_1+/+package.part_2+/profiles/default/types/ftw.simplelayout.ContentPage.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<object name="ftw.simplelayout.ContentPage" meta_type="Dexterity FTI">
+
+    <property name="behaviors" purge="False">
+        <element value="plone.app.dexterity.behaviors.exclfromnav.IExcludeFromNavigation" />
+    </property>
+
+</object>

--- a/bobtemplates/workspace/+package.fullname+/+package.part_1+/+package.part_2+/profiles/default/types/ftw.simplelayout.ContentPage.xml
+++ b/bobtemplates/workspace/+package.fullname+/+package.part_1+/+package.part_2+/profiles/default/types/ftw.simplelayout.ContentPage.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<object name="ftw.simplelayout.ContentPage" meta_type="Dexterity FTI">
+
+    <property name="behaviors" purge="False">
+        <element value="plone.app.dexterity.behaviors.exclfromnav.IExcludeFromNavigation" />
+    </property>
+
+</object>


### PR DESCRIPTION
Add behavior to exclude from navigation to the following types in following templates:

Web:

ftw.simplelayout.Contentpage
ftw.news.NewsFolder

Workspace

ftw.simplelayout.Contentpage
