### PR TITLE
Register resources at the right place.

### DIFF
--- a/bobtemplates/web/+package.fullname+/+package.part_1+/+package.part_2+/resources.zcml.bob
+++ b/bobtemplates/web/+package.fullname+/+package.part_1+/+package.part_2+/resources.zcml.bob
@@ -8,8 +8,9 @@
     <browser:resourceDirectory name="{{{package.fullname}}}" directory="resources" />
 
     <theme:resources profile="{{{package.fullname}}}:default" slot="policy">
-        <theme:scss file="resources/scss/variables.scss" slot="variables" after="ftw.theming:portal_url"/>
-        <theme:scss file="resources/scss/layout.scss" />
+        <theme:scss file="resources/scss/config.scss" slot="variables" before="ftw.theming:resources/scss/globals/variables.scss"/>
+        <theme:scss file="resources/scss/variables.scss" slot="variables" after="ftw.theming:resources/scss/globals/variables.scss"/>
+        <theme:scss file="resources/scss/policy.scss" />
     </theme:resources>
 
 </configure>

--- a/bobtemplates/web/+package.fullname+/+package.part_1+/+package.part_2+/resources/scss/config.scss
+++ b/bobtemplates/web/+package.fullname+/+package.part_1+/+package.part_2+/resources/scss/config.scss
@@ -1,0 +1,4 @@
+/*
+  If you want to override existing variables from ftw.theming or
+  plonetheme.blueberry, you have to use this file.
+ */

--- a/bobtemplates/web/+package.fullname+/+package.part_1+/+package.part_2+/resources/scss/policy.scss
+++ b/bobtemplates/web/+package.fullname+/+package.part_1+/+package.part_2+/resources/scss/policy.scss
@@ -1,0 +1,3 @@
+/*
+  Add all policy-specific stylings into this file.
+*/

--- a/bobtemplates/web/+package.fullname+/+package.part_1+/+package.part_2+/resources/scss/variables.scss
+++ b/bobtemplates/web/+package.fullname+/+package.part_1+/+package.part_2+/resources/scss/variables.scss
@@ -1,0 +1,3 @@
+/*
+  To create new scss-variables you can use this file
+*/


### PR DESCRIPTION
The theming-resources where registered not properly.

It was not possible to override variables from `ftw.theming` because the `variables.scss` file was added after the `ftw.theming` variables. Variables defined as `!default` will be set if no other package has set this variable. So we have to set our default variables before.

closes #82 
