### PR TITLE
Add ftw.tika default profile to generic setup

### DIFF
--- a/bobtemplates/workspace/+package.fullname+/+package.part_1+/+package.part_2+/profiles/default/metadata.xml
+++ b/bobtemplates/workspace/+package.fullname+/+package.part_1+/+package.part_2+/profiles/default/metadata.xml
@@ -1,15 +1,16 @@
 <?xml version="1.0"?>
 <metadata>
     <dependencies>
-        <dependency>profile-ftw.simplelayout.contenttypes:default</dependency>
-        <dependency>profile-ftw.footer:default</dependency>
-        <dependency>profile-ftw.mobilenavigation:default</dependency>
-        <dependency>profile-ftw.upgrade:default</dependency>
-        <dependency>profile-ftw.lawgiver:default</dependency>
-        <dependency>profile-ftw.statusmap:default</dependency>
         <dependency>profile-ftw.contentmenu:default</dependency>
-        <dependency>profile-ftw.workspace:default</dependency>
+        <dependency>profile-ftw.footer:default</dependency>
+        <dependency>profile-ftw.lawgiver:default</dependency>
+        <dependency>profile-ftw.mobilenavigation:default</dependency>
+        <dependency>profile-ftw.simplelayout.contenttypes:default</dependency>
+        <dependency>profile-ftw.statusmap:default</dependency>
+        <dependency>profile-ftw.tika:default</dependency>
+        <dependency>profile-ftw.upgrade:default</dependency>
         <dependency>profile-ftw.usermanagement:default</dependency>
+        <dependency>profile-ftw.workspace:default</dependency>
         <dependency>profile-plonetheme.teamraum:default</dependency>
     </dependencies>
 </metadata>

--- a/bobtemplates/workspace/+package.fullname+/deployment-+package.server_name+-+package.deployment_number+-+package.deployment_label+.cfg.bob
+++ b/bobtemplates/workspace/+package.fullname+/deployment-+package.server_name+-+package.deployment_number+-+package.deployment_label+.cfg.bob
@@ -7,6 +7,7 @@ extends =
     sources.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/warmup.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/authentication.cfg
+    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/tika-jaxrs-server.cfg
 
 
 deployment-number = {{{package.deployment_number}}}

--- a/bobtemplates/workspace/+package.fullname+/development.cfg.bob
+++ b/bobtemplates/workspace/+package.fullname+/development.cfg.bob
@@ -3,3 +3,4 @@ extends =
     test-plone-{{{package.plone_version}}}.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/plone-development.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/checkversions.cfg
+    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/plone-development-tika.cfg


### PR DESCRIPTION
Adds the generic setup profile for ftw.tika to the metadata file. Also adds both configs (development & deployment) to the buildout files.
