### PR TITLE
Add simplified plone version for pypi classifiers

### DIFF
--- a/autogenerate/module.ini
+++ b/autogenerate/module.ini
@@ -11,3 +11,4 @@ package.part_1_upper = EXAMPLE
 package.part_1_capitalized = Example
 package.part_2_capitalized = Module
 package.fullname_underscore = example_module
+package.classifier_version = 4.3

--- a/bobtemplates/hooks.py
+++ b/bobtemplates/hooks.py
@@ -31,3 +31,15 @@ def post_package_name(configurator, question, answer):
 def pre_skip_configure_deployment(configurator, question):
     if not configurator.variables['package.configure_deployment']:
         raise(SkipQuestion)
+
+
+def get_plone_classifier_version(configurator, question, answer):
+    an_split = answer.split('.')
+
+    if len(an_split) <= 1:
+        raise ValidationError(
+            'The plone version needs to have at least 2 digits e.g.: 4.3')
+
+    configurator.variables['package.classifier_version'] = '.'.join(an_split[:2])
+
+    return answer

--- a/bobtemplates/module/+package.fullname+/setup.py.bob
+++ b/bobtemplates/module/+package.fullname+/setup.py.bob
@@ -26,7 +26,7 @@ setup(
     # http://www.python.org/pypi?%3Aaction=list_classifiers
     classifiers=[
         'Framework :: Plone',
-        'Framework :: Plone :: {{{package.plone_version}}}',
+        'Framework :: Plone :: {{{package.classifier_version}}}',
         'License :: OSI Approved :: GNU General Public License (GPL)',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2.7',

--- a/bobtemplates/module/.mrbob.ini
+++ b/bobtemplates/module/.mrbob.ini
@@ -5,3 +5,4 @@ package.fullname.post_ask_question = bobtemplates.hooks:post_package_name
 
 package.plone_version.question = Basic: Enter the desired plone version (e.g.: 4.3.x)
 package.plone_version.required = True
+package.plone_version.post_ask_question = bobtemplates.hooks:get_plone_classifier_version


### PR DESCRIPTION
Adds a simpliefied 2-digit plone version to the package vars which is used to configure the pypi classifiers.

closes #83 
