### PR TITLE
Fix name of test class & update workflow definition

### DIFF
--- a/bobtemplates/web/+package.fullname+/+package.part_1+/+package.part_2+/profiles/default/workflows/+package.fullname_underscore+_workflow/definition.xml.bob
+++ b/bobtemplates/web/+package.fullname+/+package.part_1+/+package.part_2+/profiles/default/workflows/+package.fullname_underscore+_workflow/definition.xml.bob
@@ -313,12 +313,7 @@
       <permission-role>Reviewer</permission-role>
       <permission-role>Site Administrator</permission-role>
     </permission-map>
-    <permission-map name="ftw.subsite: Add Subsite" acquired="False">
-      <permission-role>Editor</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>Reviewer</permission-role>
-      <permission-role>Site Administrator</permission-role>
-    </permission-map>
+    <permission-map name="ftw.subsite: Add Subsite" acquired="False"/>
     <permission-map name="iterate : Check in content" acquired="False">
       <permission-role>Manager</permission-role>
       <permission-role>Reviewer</permission-role>
@@ -656,12 +651,7 @@
       <permission-role>Reviewer</permission-role>
       <permission-role>Site Administrator</permission-role>
     </permission-map>
-    <permission-map name="ftw.subsite: Add Subsite" acquired="False">
-      <permission-role>Editor</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>Reviewer</permission-role>
-      <permission-role>Site Administrator</permission-role>
-    </permission-map>
+    <permission-map name="ftw.subsite: Add Subsite" acquired="False"/>
     <permission-map name="iterate : Check in content" acquired="False">
       <permission-role>Editor</permission-role>
       <permission-role>Manager</permission-role>
@@ -987,12 +977,7 @@
       <permission-role>Reviewer</permission-role>
       <permission-role>Site Administrator</permission-role>
     </permission-map>
-    <permission-map name="ftw.subsite: Add Subsite" acquired="False">
-      <permission-role>Editor</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>Reviewer</permission-role>
-      <permission-role>Site Administrator</permission-role>
-    </permission-map>
+    <permission-map name="ftw.subsite: Add Subsite" acquired="False"/>
     <permission-map name="iterate : Check in content" acquired="False">
       <permission-role>Manager</permission-role>
       <permission-role>Reviewer</permission-role>

--- a/bobtemplates/web/+package.fullname+/+package.part_1+/+package.part_2+/tests/test_workflows.py.bob
+++ b/bobtemplates/web/+package.fullname+/+package.part_1+/+package.part_2+/tests/test_workflows.py.bob
@@ -2,6 +2,6 @@ from {{{package.fullname}}}.testing import {{{package.part_1_upper}}}_FUNCTIONAL
 from ftw.lawgiver.tests.base import WorkflowTest
 
 
-class TestSESWebWorkflowSpecification(WorkflowTest):
+class Test{{{package.part_1_upper}}}WebWorkflowSpecification(WorkflowTest):
     layer = {{{package.part_1_upper}}}_FUNCTIONAL
     workflow_path = '../profiles/default/workflows/{{{package.fullname_underscore}}}_workflow'


### PR DESCRIPTION
Fixes generated name of testclass in web template.

Also adds the new definition for the workflow changes caused by ftw.subsite.

closes #85 
