### PR TITLE
Fix version pinning for plone hotfixes

### DIFF
--- a/bobtemplates/module/+package.fullname+/development.cfg.bob
+++ b/bobtemplates/module/+package.fullname+/development.cfg.bob
@@ -1,4 +1,4 @@
 [buildout]
 extends =
-    test-plone-{{{package.plone_version}}}.cfg
+    test-plone-{{{package.classifier_version}}}.x.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/plone-development.cfg

--- a/bobtemplates/module/+package.fullname+/test-plone-+package.classifier_version+.x.cfg.bob
+++ b/bobtemplates/module/+package.fullname+/test-plone-+package.classifier_version+.x.cfg.bob
@@ -1,0 +1,6 @@
+[buildout]
+extends =
+    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-plone-{{{package.classifier_version}}}.x.cfg
+    sources.cfg
+
+package-name = {{{package.fullname}}}

--- a/bobtemplates/module/+package.fullname+/test-plone-+package.plone_version+.cfg.bob
+++ b/bobtemplates/module/+package.fullname+/test-plone-+package.plone_version+.cfg.bob
@@ -1,6 +1,0 @@
-[buildout]
-extends =
-    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-plone-{{{package.plone_version}}}.cfg
-    sources.cfg
-
-package-name = {{{package.fullname}}}


### PR DESCRIPTION
Uses the classifier-version of the module package, which consists of exactely 2 digits, then adds an extra ".x" to it to use the correct hotfix config. E.g.: `3.9.x``

closes #81
