### PR TITLE
Various improvements for module template

### DIFF
--- a/autogenerate/module.ini
+++ b/autogenerate/module.ini
@@ -10,5 +10,6 @@ package.part_2 = module
 package.part_1_upper = EXAMPLE
 package.part_1_capitalized = Example
 package.part_2_capitalized = Module
+package.part_2_upper = MODULE
 package.fullname_underscore = example_module
 package.classifier_version = 4.3

--- a/bobtemplates/hooks.py
+++ b/bobtemplates/hooks.py
@@ -20,6 +20,7 @@ def post_package_name(configurator, question, answer):
     configurator.variables['package.part_1_capitalized'] = part_1.capitalize()
 
     configurator.variables['package.part_2'] = part_2
+    configurator.variables['package.part_2_upper'] = part_2.upper()
     configurator.variables['package.part_2_capitalized'] = part_2.capitalize()
 
     configurator.variables['package.fullname_underscore'] = "{}_{}".format(

--- a/bobtemplates/module/+package.fullname+/+package.part_1+/+package.part_2+/testing.py.bob
+++ b/bobtemplates/module/+package.fullname+/+package.part_1+/+package.part_2+/testing.py.bob
@@ -23,7 +23,6 @@ class {{{package.part_1_capitalized}}}Layer(PloneSandboxLayer):
 
         z2.installProduct(app, '{{{package.fullname}}}')
 
-
     def setUpPloneSite(self, portal):
         applyProfile(portal, '{{{package.fullname}}}:default')
 

--- a/bobtemplates/module/+package.fullname+/+package.part_1+/+package.part_2+/testing.py.bob
+++ b/bobtemplates/module/+package.fullname+/+package.part_1+/+package.part_2+/testing.py.bob
@@ -9,7 +9,7 @@ from plone.testing import z2
 from zope.configuration import xmlconfig
 
 
-class {{{package.part_1_capitalized}}}Layer(PloneSandboxLayer):
+class {{{package.part_2_capitalized}}}Layer(PloneSandboxLayer):
     defaultBases = (PLONE_FIXTURE, BUILDER_LAYER)
 
     def setUpZope(self, app, configurationContext):
@@ -27,8 +27,8 @@ class {{{package.part_1_capitalized}}}Layer(PloneSandboxLayer):
         applyProfile(portal, '{{{package.fullname}}}:default')
 
 
-{{{package.part_1_upper}}}_FIXTURE = {{{package.part_1_capitalized}}}Layer()
-{{{package.part_1_upper}}}_FUNCTIONAL = FunctionalTesting(
-    bases=({{{package.part_1_upper}}}_FIXTURE,
+{{{package.part_2_upper}}}_FIXTURE = {{{package.part_2_capitalized}}}Layer()
+{{{package.part_2_upper}}}_FUNCTIONAL = FunctionalTesting(
+    bases=({{{package.part_2_upper}}}_FIXTURE,
            set_builder_session_factory(functional_session_factory)),
     name="{{{package.fullname}}}:functional")

--- a/bobtemplates/module/+package.fullname+/+package.part_1+/+package.part_2+/tests/__init__.py.bob
+++ b/bobtemplates/module/+package.fullname+/+package.part_1+/+package.part_2+/tests/__init__.py.bob
@@ -1,4 +1,4 @@
-from {{{package.fullname}}}.testing import {{{package.part_1_upper}}}_FUNCTIONAL
+from {{{package.fullname}}}.testing import {{{package.part_2_upper}}}_FUNCTIONAL
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
 from unittest2 import TestCase
@@ -6,7 +6,7 @@ import transaction
 
 
 class FunctionalTestCase(TestCase):
-    layer = {{{package.part_1_upper}}}_FUNCTIONAL
+    layer = {{{package.part_2_upper}}}_FUNCTIONAL
 
     def setUp(self):
         self.portal = self.layer['portal']

--- a/bobtemplates/module/+package.fullname+/README.rst.bob
+++ b/bobtemplates/module/+package.fullname+/README.rst.bob
@@ -37,7 +37,7 @@ Development
 
 1. Fork this repo
 2. Clone your fork
-3. Shell: ``ln -s development.cfg buidlout.cfg``
+3. Shell: ``ln -s development.cfg buildout.cfg``
 4. Shell: ``python boostrap.py``
 5. Shell: ``bin/buildout``
 

--- a/bobtemplates/module/+package.fullname+/README.rst.bob
+++ b/bobtemplates/module/+package.fullname+/README.rst.bob
@@ -33,8 +33,6 @@ Usage
 Development
 ===========
 
-**Python:**
-
 1. Fork this repo
 2. Clone your fork
 3. Shell: ``ln -s development.cfg buildout.cfg``

--- a/bobtemplates/module/+package.fullname+/README.rst.bob
+++ b/bobtemplates/module/+package.fullname+/README.rst.bob
@@ -52,7 +52,6 @@ Links
 - Github: https://github.com/4teamwork/{{{package.fullname}}}
 - Issues: https://github.com/4teamwork/{{{package.fullname}}}/issues
 - Pypi: http://pypi.python.org/pypi/{{{package.fullname}}}
-- Continuous integration: https://jenkins.4teamwork.ch/search?q={{{package.fullname}}}
 
 
 Copyright

--- a/bobtemplates/module/+package.fullname+/README.rst.bob
+++ b/bobtemplates/module/+package.fullname+/README.rst.bob
@@ -25,11 +25,6 @@ Installation
         {{{package.fullname}}}
 
 
-Usage
-=====
-
-### USAGE ###
-
 Development
 ===========
 

--- a/bobtemplates/module/+package.fullname+/docs/HISTORY.txt
+++ b/bobtemplates/module/+package.fullname+/docs/HISTORY.txt
@@ -5,4 +5,4 @@ Changelog
 1.0.0 (unreleased)
 --------------------
 
-- Package generated using bobtemplates.4teamwork
+- Initial implementation.

--- a/bobtemplates/module/+package.fullname+/docs/LICENSE.GPL
+++ b/bobtemplates/module/+package.fullname+/docs/LICENSE.GPL
@@ -1,0 +1,222 @@
+		    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+			    NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+		     END OF TERMS AND CONDITIONS

--- a/bobtemplates/module/+package.fullname+/docs/LICENSE.txt.bob
+++ b/bobtemplates/module/+package.fullname+/docs/LICENSE.txt.bob
@@ -1,0 +1,16 @@
+  {{{package.fullname}}} is copyright 4teamwork AG
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+  MA 02111-1307 USA.

--- a/bobtemplates/module/+package.fullname+/setup.py.bob
+++ b/bobtemplates/module/+package.fullname+/setup.py.bob
@@ -45,8 +45,6 @@ setup(
 
     install_requires=[
         'Plone',
-        'plone.app.dexterity',
-        'plone.dexterity',
         'setuptools',
     ],
 

--- a/bobtemplates/module/+package.fullname+/setup.py.bob
+++ b/bobtemplates/module/+package.fullname+/setup.py.bob
@@ -4,8 +4,8 @@ version = '1.0.0.dev0'
 
 tests_require = [
     'ftw.builder',
-    'ftw.testing',
     'ftw.testbrowser',
+    'ftw.testing',
     'plone.app.testing',
     'plone.testing',
 ]
@@ -44,10 +44,10 @@ setup(
     zip_safe=False,
 
     install_requires=[
-        'setuptools',
-        'plone.dexterity',
-        'plone.app.dexterity',
         'Plone',
+        'plone.app.dexterity',
+        'plone.dexterity',
+        'setuptools',
     ],
 
     tests_require=tests_require,

--- a/bobtemplates/module/+package.fullname+/setup.py.bob
+++ b/bobtemplates/module/+package.fullname+/setup.py.bob
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-version = '1.0.0a1.dev0'
+version = '1.0.0.dev0'
 maintainer = '4teamwork'
 
 tests_require = [

--- a/bobtemplates/module/+package.fullname+/setup.py.bob
+++ b/bobtemplates/module/+package.fullname+/setup.py.bob
@@ -1,7 +1,6 @@
 from setuptools import setup, find_packages
 
 version = '1.0.0.dev0'
-maintainer = '4teamwork'
 
 tests_require = [
     'ftw.builder',
@@ -36,7 +35,6 @@ setup(
     keywords='{{{package.part_1}}} {{{package.part_2}}}',
     author='4teamwork AG',
     author_email='mailto:info@4teamwork.ch',
-    maintainer=maintainer,
     url='https://github.com/4teamwork/{{{package.fullname}}}',
     license='GPL2',
 


### PR DESCRIPTION
- readme: fix typo.
- readme: remove CI link; not working anymore.
- history: replace initial entry.
- add license files.
- setup.py: do not start with alpha version.
- setup.py: remove maintainer.
- setup.py: reorder dependencies.
- setup.py: do not install dexterity.
- testing.py: pep8.
- testing: use second part of package name for layer names.
