### PR TITLE
Use name according to the generated package in byline viewlet

### DIFF
--- a/bobtemplates/web/+package.fullname+/+package.part_1+/+package.part_2+/viewlets/byline.py.bob
+++ b/bobtemplates/web/+package.fullname+/+package.part_1+/+package.part_2+/viewlets/byline.py.bob
@@ -1,9 +1,9 @@
 from plone.app.layout.viewlets.content import DocumentBylineViewlet
 
 
-class BaselDocumentBylineViewlet(DocumentBylineViewlet):
+class {{{package.part_1}}}DocumentBylineViewlet(DocumentBylineViewlet):
 
     def show(self):
         if self.request.get('disable_border', False):
             return False
-        return super(BaselDocumentBylineViewlet, self).show()
+        return super({{{package.part_1}}}DocumentBylineViewlet, self).show()

--- a/bobtemplates/web/+package.fullname+/+package.part_1+/+package.part_2+/viewlets/configure.zcml.bob
+++ b/bobtemplates/web/+package.fullname+/+package.part_1+/+package.part_2+/viewlets/configure.zcml.bob
@@ -6,7 +6,7 @@
 
     <browser:viewlet
         name="plone.belowcontenttitle.documentbyline"
-        class=".byline.BaselDocumentBylineViewlet"
+        class=".byline.{{{package.part_1}}}DocumentBylineViewlet"
         manager="plone.app.layout.viewlets.interfaces.IBelowContentTitle"
         permission="zope2.View"
         layer="{{{package.fullname}}}.interfaces.I{{{package.part_1_capitalized}}}{{{package.part_2_capitalized}}}Layer"

--- a/bobtemplates/workspace/+package.fullname+/+package.part_1+/+package.part_2+/viewlets/byline.py.bob
+++ b/bobtemplates/workspace/+package.fullname+/+package.part_1+/+package.part_2+/viewlets/byline.py.bob
@@ -1,9 +1,9 @@
 from plone.app.layout.viewlets.content import DocumentBylineViewlet
 
 
-class BaselDocumentBylineViewlet(DocumentBylineViewlet):
+class {{{package.part_1}}}DocumentBylineViewlet(DocumentBylineViewlet):
 
     def show(self):
         if self.request.get('disable_border', False):
             return False
-        return super(BaselDocumentBylineViewlet, self).show()
+        return super({{{package.part_1}}}DocumentBylineViewlet, self).show()

--- a/bobtemplates/workspace/+package.fullname+/+package.part_1+/+package.part_2+/viewlets/configure.zcml.bob
+++ b/bobtemplates/workspace/+package.fullname+/+package.part_1+/+package.part_2+/viewlets/configure.zcml.bob
@@ -6,7 +6,7 @@
 
     <browser:viewlet
         name="plone.belowcontenttitle.documentbyline"
-        class=".byline.BaselDocumentBylineViewlet"
+        class=".byline.{{{package.part_1}}}DocumentBylineViewlet"
         manager="plone.app.layout.viewlets.interfaces.IBelowContentTitle"
         permission="zope2.View"
         layer="{{{package.fullname}}}.interfaces.I{{{package.part_1_capitalized}}}{{{package.part_2_capitalized}}}Layer"


### PR DESCRIPTION
Until now the name was always set to basel. This changes this behaviour so the name of the viewlet is always the one of the package being generated.

closes #121