### PR TITLE
Add JS to list of available templates in readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,6 +33,8 @@ The following templates are available and ready to generate:
   Use this template to generate a workspace based on ftw.workspace
 ``module``
   Use this template if you want to start with a new ftw-module
+``javascript``
+  Use this template to generate a javascript python package
 
 Generating a new policy package
 -------------------------------


### PR DESCRIPTION
There is actually a template for JS packages. It was just not added to the list of available templates yet...