### PR TITLE
Use stable release of ftw.mobile instead of unreleased version

### DIFF
--- a/bobtemplates/web/+package.fullname+/sources.cfg
+++ b/bobtemplates/web/+package.fullname+/sources.cfg
@@ -4,6 +4,3 @@ extends =
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/4teamwork-psc.cfg
 
 extensions += mr.developer
-
-auto-checkout +=
-    ftw.mobile


### PR DESCRIPTION
New Webpolicies now use the latest release of `ftw.mobile` instead of the unreleased version from Github.

closes #126 