### PR TITLE
Create tmp directory and symlink on package creation

### DIFF
--- a/bobtemplates/hooks.py
+++ b/bobtemplates/hooks.py
@@ -53,20 +53,24 @@ def get_plone_classifier_version(configurator, question, answer):
     return answer
 
 
-def download_deploy_scripts(configurator):
+def prepare_push_deployment(configurator):
+    # Downloads deploy scripts and creates a symlink (log -> var/log)
     deploy_scripts = {
         'pull': requests.get('https://raw.githubusercontent.com/4teamwork/plone-git-deployment/master/deploy/pull'),
         'after_push': requests.get('https://raw.githubusercontent.com/4teamwork/plone-git-deployment/master/deploy/after_push'),
         'update_plone': requests.get('https://raw.githubusercontent.com/4teamwork/plone-git-deployment/master/deploy/update_plone')
     }
 
-    path = os.path.join(os.getcwd(),
-                        'generated',
-                        configurator.variables['package.fullname'],
-                        'deploy')
+    package_path = os.path.join(os.getcwd(),
+                                'generated',
+                                configurator.variables['package.fullname'])
 
-    os.makedirs(path)
+    scripts_path = os.path.join(package_path, 'deploy')
+
+    os.makedirs(scripts_path)
 
     for filename, content in deploy_scripts.iteritems():
-        with open(os.path.join(path, filename), 'w') as script:
+        with open(os.path.join(scripts_path, filename), 'w') as script:
             script.write(content.text)
+
+    os.symlink('var/log', os.path.join(package_path, 'log'))

--- a/bobtemplates/intranet/+package.fullname+/tmp/.gitignore
+++ b/bobtemplates/intranet/+package.fullname+/tmp/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/bobtemplates/intranet/.mrbob.ini
+++ b/bobtemplates/intranet/.mrbob.ini
@@ -26,4 +26,4 @@ package.deployment_label.required = True
 package.deployment_label.default = production
 
 [template]
-post_render = bobtemplates.hooks:download_deploy_scripts
+post_render = bobtemplates.hooks:prepare_push_deployment

--- a/bobtemplates/web/+package.fullname+/scripts/setup-git-remotes.bob
+++ b/bobtemplates/web/+package.fullname+/scripts/setup-git-remotes.bob
@@ -12,10 +12,3 @@ setup_remote () {
 }
 
 setup_remote "{{{package.deployment_label}}}" "zope@{{{package.server_name}}}:{{{package.deployment_path}}}"
-
-cd $(dirname "$0")/..
-ln -s var/log
-mkdir tmp
-cd tmp
-echo "*" > .gitignore
-echo "!.gitignore" >> .gitignore

--- a/bobtemplates/web/+package.fullname+/tmp/.gitignore
+++ b/bobtemplates/web/+package.fullname+/tmp/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/bobtemplates/web/.mrbob.ini
+++ b/bobtemplates/web/.mrbob.ini
@@ -26,4 +26,4 @@ package.deployment_label.required = True
 package.deployment_label.default = production
 
 [template]
-post_render = bobtemplates.hooks:download_deploy_scripts
+post_render = bobtemplates.hooks:prepare_push_deployment

--- a/bobtemplates/workspace/+package.fullname+/scripts/setup-git-remotes.bob
+++ b/bobtemplates/workspace/+package.fullname+/scripts/setup-git-remotes.bob
@@ -12,10 +12,3 @@ setup_remote () {
 }
 
 setup_remote "{{{package.deployment_label}}}" "zope@{{{package.server_name}}}:{{{package.deployment_path}}}"
-
-cd $(dirname "$0")/..
-ln -s var/log
-mkdir tmp
-cd tmp
-echo "*" > .gitignore
-echo "!.gitignore" >> .gitignore

--- a/bobtemplates/workspace/+package.fullname+/tmp/.gitignore
+++ b/bobtemplates/workspace/+package.fullname+/tmp/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/bobtemplates/workspace/.mrbob.ini
+++ b/bobtemplates/workspace/.mrbob.ini
@@ -26,4 +26,4 @@ package.deployment_label.required = True
 package.deployment_label.default = production
 
 [template]
-post_render = bobtemplates.hooks:get_deploy_scripts
+post_render = bobtemplates.hooks:prepare_push_deployment

--- a/bobtemplates/workspace/.mrbob.ini
+++ b/bobtemplates/workspace/.mrbob.ini
@@ -25,4 +25,5 @@ package.deployment_label.question = Deployment: Enter the deployment label (e.g.
 package.deployment_label.required = True
 package.deployment_label.default = production
 
+[template]
 post_render = bobtemplates.hooks:get_deploy_scripts


### PR DESCRIPTION
As stated in #135, the `tmp` directory and the symlink to the log should be created on package creation and not on execution of `scripts/setup-git-remotes`.

This is now done using the `post_render` hook of bobtemplates in `web`, `intranet` and `workspace`. The `module` and `javascript` packages don't need push deployment.

closes #135 