### PR TITLE
Set default value for plone version instead of "e.g." in all templates

### DIFF
--- a/bobtemplates/intranet/.mrbob.ini
+++ b/bobtemplates/intranet/.mrbob.ini
@@ -6,8 +6,9 @@ package.fullname.question = Basic: Package name (e.g.: company.intranet)
 package.fullname.required = True
 package.fullname.post_ask_question = bobtemplates.hooks:post_package_name
 
-package.plone_version.question = Basic: Enter the desired plone version (e.g.: 4.3.14)
+package.plone_version.question = Basic: Enter the desired plone version
 package.plone_version.required = True
+package.plone_version.default = 4.3.14
 
 package.server_name.question = Deployment: Enter the servername
 package.server_name.required = True

--- a/bobtemplates/javascript/.mrbob.ini
+++ b/bobtemplates/javascript/.mrbob.ini
@@ -3,7 +3,7 @@ package.fullname.question = Basic: Package name (e.g.: ftw.package)
 package.fullname.required = True
 package.fullname.post_ask_question = bobtemplates.hooks:post_package_name
 
-package.plone_version.question = Basic: Enter the desired plone version (e.g.: 4.3.x)
+package.plone_version.question = Basic: Enter the desired plone version
 package.plone_version.required = True
-package.plone_version.default = 4.3.x
+package.plone_version.default = 4.3.14
 package.plone_version.post_ask_question = bobtemplates.hooks:get_plone_classifier_version

--- a/bobtemplates/module/.mrbob.ini
+++ b/bobtemplates/module/.mrbob.ini
@@ -3,6 +3,7 @@ package.fullname.question = Basic: Package name (e.g.: ftw.package)
 package.fullname.required = True
 package.fullname.post_ask_question = bobtemplates.hooks:post_package_name
 
-package.plone_version.question = Basic: Enter the desired plone version (e.g.: 4.3.x)
+package.plone_version.question = Basic: Enter the desired plone version
 package.plone_version.required = True
+package.plone_version.default = 4.3.14
 package.plone_version.post_ask_question = bobtemplates.hooks:get_plone_classifier_version

--- a/bobtemplates/web/.mrbob.ini
+++ b/bobtemplates/web/.mrbob.ini
@@ -6,8 +6,9 @@ package.fullname.question = Basic: Package name (e.g.: company.web)
 package.fullname.required = True
 package.fullname.post_ask_question = bobtemplates.hooks:post_package_name
 
-package.plone_version.question = Basic: Enter the desired plone version (e.g.: 4.3.9)
+package.plone_version.question = Basic: Enter the desired plone version
 package.plone_version.required = True
+package.plone_version.default = 4.3.14
 
 package.server_name.question = Deployment: Enter the servername
 package.server_name.required = True

--- a/bobtemplates/workspace/.mrbob.ini
+++ b/bobtemplates/workspace/.mrbob.ini
@@ -6,8 +6,9 @@ package.fullname.question = Basic: Package name (e.g.: company.web)
 package.fullname.required = True
 package.fullname.post_ask_question = bobtemplates.hooks:post_package_name
 
-package.plone_version.question = Basic: Enter the desired plone version (e.g.: 4.3.9)
+package.plone_version.question = Basic: Enter the desired plone version
 package.plone_version.required = True
+package.plone_version.default = 4.3.14
 
 package.server_name.question = Deployment: Enter the servername
 package.server_name.required = True


### PR DESCRIPTION
Set a default value for the plone version question in all templates. IMO this is better than the "e.g. ..." part in the question. The user still gets an idea what the plone version should be like since bobtemplates prints the default value in brackets behind the question:

`--> Basic: Enter the desired plone version [4.3.14]:`