### PR TITLE
Install select2js profile of ftw.keywordwidget

### DIFF
--- a/bobtemplates/intranet/+package.fullname+/+package.part_1+/+package.part_2+/profiles/default/metadata.xml
+++ b/bobtemplates/intranet/+package.fullname+/+package.part_1+/+package.part_2+/profiles/default/metadata.xml
@@ -27,5 +27,6 @@
         <dependency>profile-ftw.dashboard.portlets.recentlymodified:default</dependency>
         <dependency>profile-ftw.dashboard.dragndrop:default</dependency>
         <dependency>profile-ftw.protectinactive:default</dependency>
+        <dependency>profile-ftw.keywordwidget:select2js</dependency>
     </dependencies>
 </metadata>

--- a/bobtemplates/web/+package.fullname+/+package.part_1+/+package.part_2+/profiles/default/metadata.xml
+++ b/bobtemplates/web/+package.fullname+/+package.part_1+/+package.part_2+/profiles/default/metadata.xml
@@ -18,5 +18,6 @@
         <dependency>profile-ftw.lawgiver:default</dependency>
         <dependency>profile-ftw.statusmap:default</dependency>
         <dependency>profile-ftw.protectinactive:default</dependency>
+        <dependency>profile-ftw.keywordwidget:select2js</dependency>
     </dependencies>
 </metadata>


### PR DESCRIPTION
When this profile was not installed, there was a javascript error when editing some simplelayout blocks (e.g. NewsListingBlock)
Installing this profile fixes this issue.

closes #138 