### PR TITLE
Add exclude from navigation behaviour to contentpage in intranet template

### DIFF
--- a/bobtemplates/intranet/+package.fullname+/+package.part_1+/+package.part_2+/profiles/default/types/ftw.simplelayout.ContentPage.xml
+++ b/bobtemplates/intranet/+package.fullname+/+package.part_1+/+package.part_2+/profiles/default/types/ftw.simplelayout.ContentPage.xml
@@ -3,6 +3,10 @@
         meta_type="Dexterity FTI"
         xmlns:i18n="http://xml.zope.org/namespaces/i18n">
 
+    <property name="behaviors" purge="False">
+        <element value="plone.app.dexterity.behaviors.exclfromnav.IExcludeFromNavigation" />
+    </property>
+
     <property name="allowed_content_types" purge="False">
         <element value="BillboardCategory" />
         <element value="ftw.contacts.ContactFolder" />


### PR DESCRIPTION
The "exclude from navigation" behaviour should also be included by default in the intranet template.