### PR TITLE
Prevent version conflict between "ftw.workspace" and "bumblebee.file". 

### DIFF
--- a/bobtemplates/workspace/+package.fullname+/+package.part_1+/+package.part_2+/profiles/default/workflows/workspace_content_workflow/definition.xml.bob
+++ b/bobtemplates/workspace/+package.fullname+/+package.part_1+/+package.part_2+/profiles/default/workflows/workspace_content_workflow/definition.xml.bob
@@ -52,6 +52,8 @@
   <permission>ftw.contentpage: Edit teaser image on News</permission>
   <permission>ftw.contentpage: Toggle IAuthority marker interface</permission>
   <permission>ftw.file: Add File</permission>
+  <permission>ftw.file: Edit advanced fields</permission>
+  <permission>ftw.file: Edit date fields</permission>
   <permission>ftw.footer: Manage Footer</permission>
   <permission>ftw.meeting: Add Meeting</permission>
   <permission>ftw.meeting: Add Meeting Item</permission>
@@ -321,6 +323,12 @@
       <permission-role>Editor</permission-role>
       <permission-role>Manager</permission-role>
       <permission-role>Owner</permission-role>
+    </permission-map>
+    <permission-map name="ftw.file: Edit advanced fields" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="ftw.file: Edit date fields" acquired="False">
+      <permission-role>Manager</permission-role>
     </permission-map>
     <permission-map name="ftw.footer: Manage Footer" acquired="False"/>
     <permission-map name="ftw.meeting: Add Meeting" acquired="False">

--- a/bobtemplates/workspace/+package.fullname+/+package.part_1+/+package.part_2+/profiles/default/workflows/workspace_workflow/definition.xml.bob
+++ b/bobtemplates/workspace/+package.fullname+/+package.part_1+/+package.part_2+/profiles/default/workflows/workspace_workflow/definition.xml.bob
@@ -52,6 +52,8 @@
   <permission>ftw.contentpage: Edit teaser image on News</permission>
   <permission>ftw.contentpage: Toggle IAuthority marker interface</permission>
   <permission>ftw.file: Add File</permission>
+  <permission>ftw.file: Edit advanced fields</permission>
+  <permission>ftw.file: Edit date fields</permission>
   <permission>ftw.footer: Manage Footer</permission>
   <permission>ftw.meeting: Add Meeting</permission>
   <permission>ftw.meeting: Add Meeting Item</permission>
@@ -321,6 +323,12 @@
       <permission-role>Editor</permission-role>
       <permission-role>Manager</permission-role>
       <permission-role>Owner</permission-role>
+    </permission-map>
+    <permission-map name="ftw.file: Edit advanced fields" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="ftw.file: Edit date fields" acquired="False">
+      <permission-role>Manager</permission-role>
     </permission-map>
     <permission-map name="ftw.footer: Manage Footer" acquired="False"/>
     <permission-map name="ftw.meeting: Add Meeting" acquired="False">

--- a/bobtemplates/workspace/+package.fullname+/+package.part_1+/+package.part_2+/profiles/default/workflows/workspaces_workflow/definition.xml.bob
+++ b/bobtemplates/workspace/+package.fullname+/+package.part_1+/+package.part_2+/profiles/default/workflows/workspaces_workflow/definition.xml.bob
@@ -52,6 +52,8 @@
   <permission>ftw.contentpage: Edit teaser image on News</permission>
   <permission>ftw.contentpage: Toggle IAuthority marker interface</permission>
   <permission>ftw.file: Add File</permission>
+  <permission>ftw.file: Edit advanced fields</permission>
+  <permission>ftw.file: Edit date fields</permission>
   <permission>ftw.footer: Manage Footer</permission>
   <permission>ftw.meeting: Add Meeting</permission>
   <permission>ftw.meeting: Add Meeting Item</permission>
@@ -225,6 +227,12 @@
     <permission-map name="ftw.file: Add File" acquired="False">
       <permission-role>Manager</permission-role>
       <permission-role>Reviewer</permission-role>
+    </permission-map>
+    <permission-map name="ftw.file: Edit advanced fields" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="ftw.file: Edit date fields" acquired="False">
+      <permission-role>Manager</permission-role>
     </permission-map>
     <permission-map name="ftw.footer: Manage Footer" acquired="False"/>
     <permission-map name="ftw.meeting: Add Meeting" acquired="False">

--- a/bobtemplates/workspace/+package.fullname+/versions.cfg.bob
+++ b/bobtemplates/workspace/+package.fullname+/versions.cfg.bob
@@ -16,3 +16,6 @@ six = 1.12.0
 
 # python2 versions
 more-itertools = < 6.0
+
+# Prevent version conflict between "ftw.workspace" and "bumblebee.file".
+ftw.file = >=1.11.2, <2a


### PR DESCRIPTION
Both packages require `ftw.file`, but `bumblebee.file` limits it to a very special range of releases. This caused the following error during `bin/buildout`:

```
While:
  Installing test.
Error: There is a version conflict.
We already have: ftw.file 2.3.1
but bumblebee.file 1.5.2 requires ‘ftw.file<2a,>=1.11.2’.
```

As reported in https://ci.4teamwork.ch/builds/320903/tasks/532175