### PR TITLE
Pin down setuptools (Python2.7).

### DIFF
--- a/local.cfg
+++ b/local.cfg
@@ -40,3 +40,4 @@ zc.recipe.egg = 2.0.3
 # Pin setuptools<45. Using < raises AttributeError:
 # 'module' object has no attribute 'SetuptoolsVersion'
 setuptools = 33.1.1
+geopy = 1.23.0

--- a/local.cfg
+++ b/local.cfg
@@ -37,3 +37,6 @@ six = 1.10.0
 traceback2 = 1.4.0
 zc.buildout = 2.11.0
 zc.recipe.egg = 2.0.3
+# Pin setuptools<45. Using < raises AttributeError:
+# 'module' object has no attribute 'SetuptoolsVersion'
+setuptools = 33.1.1


### PR DESCRIPTION
Basically this PR pins down setuptools to <45. But because using `<` will raise `AttributeError: 'module' object has no attribute 'SetuptoolsVersion'` (which seems to be a known bug https://community.plone.org/t/plone-5-1-installation-abort-attributeerror-module-object-has-no-attribute-setuptoolsversion/6085) I decided to pin it to a specific version (which is known to work well -> e.g. gever).